### PR TITLE
Fix camera and microphone devices are not accessible

### DIFF
--- a/build-resources/entitlements.mac.plist
+++ b/build-resources/entitlements.mac.plist
@@ -6,5 +6,11 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Resolve #50.


In a sandboxed app, if you don't have the `com.apple.security.device.microphone` entitlement, your app will not be able to access the microphone. In a hardened app, if you don't have the `com.apple.security.device.audio-input` entitlement, your app will not be able to access the microphone or any audio input using Core Audio. Ref: https://stackoverflow.com/a/57060745